### PR TITLE
Replace play_scraper with google_play_scraper for Google Play app descriptions

### DIFF
--- a/UI_embedding/dataset/playstore_scraper.py
+++ b/UI_embedding/dataset/playstore_scraper.py
@@ -1,4 +1,4 @@
-import play_scraper
+import google_play_scraper 
 from os import path
 DEFAULT_APP_DESCRIPTION_PATH = './PlayStoreDescriptions/'
 
@@ -6,14 +6,8 @@ DEFAULT_APP_DESCRIPTION_PATH = './PlayStoreDescriptions/'
 
 def get_app_description(packageName):
     try:
-        return play_scraper.details(packageName)['description']
-    except ValueError as ve:
-        try:
-            potential_app = play_scraper.search(packageName, detailed=True)
-            return potential_app['description']
-        except Exception as e:
-            return ''
-    except Exception as e:
+        return google_play_scraper.app(packageName)['description']
+    except:
         return ''
 
 # scrape the playstore description for packageName and store it in path as a txt file
@@ -24,7 +18,7 @@ def update_app_description_file(packageName, dir_path):
         if (packageName + '\n') in unrecognizedPackageNames:
             return None
     try:
-        description = play_scraper.details(packageName)['description']
+        description = google_play_scraper.app(packageName)['description']
     except ValueError as e:
         if '404 Client Error: Not Found for url' in str(e):
             with open(dir_path + "unrecognized.text", "a") as f:

--- a/dataset/playstore_scraper.py
+++ b/dataset/playstore_scraper.py
@@ -1,4 +1,4 @@
-import play_scraper
+import google_play_scraper 
 from os import path
 DEFAULT_APP_DESCRIPTION_PATH = './PlayStoreDescriptions/'
 
@@ -6,14 +6,8 @@ DEFAULT_APP_DESCRIPTION_PATH = './PlayStoreDescriptions/'
 
 def get_app_description(packageName):
     try:
-        return play_scraper.details(packageName)['description']
-    except ValueError as ve:
-        try:
-            potential_app = play_scraper.search(packageName, detailed=True)
-            return potential_app['description']
-        except Exception as e:
-            return ''
-    except Exception as e:
+        return google_play_scraper.app(packageName)['description']
+    except:
         return ''
 
 # scrape the playstore description for packageName and store it in path as a txt file
@@ -24,7 +18,7 @@ def update_app_description_file(packageName, dir_path):
         if (packageName + '\n') in unrecognizedPackageNames:
             return None
     try:
-        description = play_scraper.details(packageName)['description']
+        description = google_play_scraper.app(packageName)['description']
     except ValueError as e:
         if '404 Client Error: Not Found for url' in str(e):
             with open(dir_path + "unrecognized.text", "a") as f:
@@ -39,5 +33,4 @@ def update_app_description_file(packageName, dir_path):
 def update_app_description_file_in_batch(packageNameList, dir_path):
     for packageName in packageNameList:
         update_app_description_file(packageName, dir_path)
-
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ tqdm
 argparse
 scipy
 sentence-transformers
-play-scraper
+google-play-scraper


### PR DESCRIPTION
### 🔗 Related Issue
Closes #6

### 📌 Summary
This PR updates playstore_scraper.py to replace the outdated play_scraper module with google_play_scraper. As noted in Issue #6, Google Play has changed its webpage structure, making play_scraper unable to retrieve app descriptions. The new library, google_play_scraper, serves as a stable and maintained alternative.

### 🛠 Changes Made
* Replaced play_scraper with google_play_scraper in playstore_scraper.py.
* Updated function calls to match the new library’s API.
* Tested to confirm successful retrieval of app descriptions.

Thank you for reviewing this PR! 🚀